### PR TITLE
update meta for new org

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -28,8 +28,8 @@ my $builder = Alien::Base::ModuleBuild->new(
   ],
   meta_merge => {
     resources => {
-      repository => 'https://github.com/Perl5-Alien/Alien-GSL', 
-      bugtracker => 'https://github.com/Perl5-Alien/Alien-GSL/issues',
+      repository => 'https://github.com/PerlAlien/Alien-GSL',
+      bugtracker => 'https://github.com/PerlAlien/Alien-GSL/issues',
     },
   },
 );

--- a/README.pod
+++ b/README.pod
@@ -68,7 +68,7 @@ L<Math::GSL>
 
 =head1 SOURCE REPOSITORY
 
-L<https://github.com/Perl5-Alien/Alien-GSL>
+L<https://github.com/PerlAlien/Alien-GSL>
 
 =head1 AUTHOR
 

--- a/lib/Alien/GSL.pm
+++ b/lib/Alien/GSL.pm
@@ -80,7 +80,7 @@ L<Math::GSL>
 
 =head1 SOURCE REPOSITORY
 
-L<https://github.com/Perl5-Alien/Alien-GSL>
+L<https://github.com/PerlAlien/Alien-GSL>
 
 =head1 AUTHOR
 


### PR DESCRIPTION
I'm in the process of moving repos to the new PerlAlien org.  This PR updates links and meta for the new repository.  I don't think a release is necessary, though it wouldn't hurt, since GitHub should redirect the appropriate URLs.  Merging this now means that the next release whenever it happens will have the right meta and links.

@jberger I can move this repo for you, or you can do it yourself.  Let me know if you want me to do it.  